### PR TITLE
Modified comment in example 9.6 for proper referencing

### DIFF
--- a/code/chapter_09_example_6.py
+++ b/code/chapter_09_example_6.py
@@ -32,7 +32,7 @@ from functools import wraps
 
 from . import utils
 
-# based off the decorator template from Example 8.5
+# based off the decorator template from Example 9.5
 def check_sprinkles(view_func):
     """Check if a user can add sprinkles"""
     @wraps(view_func)


### PR DESCRIPTION
Minor typo in a comment
